### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ wget https://raw.githubusercontent.com/IBM/cloud-pak-cli/master/cloudctl-chain1.
 #### Verify that the certificate/key is owned by IBM:
 
 ```
-openssl x509 -inform pub -in cloudctl.pub -noout -text
+openssl x509 -inform pem -in cloudctl.pub -noout -text
 ```
 
 #### Verify authenticity of certificate/key:


### PR DESCRIPTION
From SVT, this command doesn't work:
openssl x509 -inform pub -in cloudctl.pub -noout -text
It always fails with error 
x509: Invalid format "pub" for -inform
Changing "-inform pub" to "-inform pem" works.